### PR TITLE
explained relative path for images

### DIFF
--- a/.buildpath
+++ b/.buildpath
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buildpath>
+</buildpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>vlc-lua-docs</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.dltk.core.scriptbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.ldt.nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.ldt.prefs
+++ b/.settings/org.eclipse.ldt.prefs
@@ -1,0 +1,2 @@
+Grammar__default_id=lua-5.1
+eclipse.preferences.version=1

--- a/m/dialog/index.md
+++ b/m/dialog/index.md
@@ -117,7 +117,7 @@ Widgets are small components that provide most of utility and U.I. of the dialog
 | HTML | [add_html()](#dialogadd_html) | [get_text()](#widgetget_text), [set_text()](#widgetset_text) |
 | Text Input | [add_text_input()](#dialogadd_text_input) | [get_text()](#widgetget_text), [set_text()](#widgetset_text) |
 | Password | [add_password()](#dialogadd_password) | [get_text()](#widgetget_text), [set_text()](#widgetset_text) |
-| Check Box | [add_check_box()](dialogadd_check_box) | [get_text()](#widgetget_text), [set_text()](#widgetset_text), [get_checked()](#widgetget_checked), [set_checked()](#widgetset_checked) |
+| Check Box | [add_check_box()](#dialogadd_check_box) | [get_text()](#widgetget_text), [set_text()](#widgetset_text), [get_checked()](#widgetget_checked), [set_checked()](#widgetset_checked) |
 | Dropdown | [add_dropdown()](#dialogadd_dropdown) | [clear()](#widgetclear), [get_value()](#widgetget_value), [add_value()](#widgetadd_value) |
 | List | [add_list()](dialogadd_list) | [get_selection()](#widgetget_selection), [clear()](#widgetclear), [get_value()](#widgetget_value) (4.0+), [add_value()](#widgetadd_value) (4.0+) |
 | Image | [add_image()](#dialogadd_image) | None |

--- a/m/dialog/index.md
+++ b/m/dialog/index.md
@@ -305,11 +305,12 @@ Image path is absolute or relative on the local machine.
 ### Usage
 ```lua
 local dlg = vlc.dialog("My VLC Extension")
-local img_wgt = dlg:add_image("C:\\some\\path\\image.ext", ...)
+local abs_path_img_wgt = dlg:add_image("C:\\some\\path\\image.ext", ...)
+local rel_path_img_wgt = dlg:add_image("lua\\extensions\\image.ext", ...)
 ```
 
 ### Parameters
-`path` String representing the path to the image
+`path` String representing the path to the image. Relative path is relative to VLC's installation dir (usually `C:\\Program Files\\VideoLAN\\VLC` on Windows)
 - Optional
   - `...` [Widget](#widget-parameters) parameters
 


### PR DESCRIPTION
Explained that widget's image relative path is relative to main VLC's installation folder.